### PR TITLE
Makefile: install/uninstall: implement DESTDIR, follow GNU conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,18 @@
+# Common prefix for installation directories, following GNU conventions.
+# See https://www.gnu.org/prep/standards/html_node/Directory-Variables.html for details.
+
+# Installation prefix
+PREFIX = /usr/local
+DATAROOTDIR = $(PREFIX)/share
+
+# Where to put the executable.
+BINDIR = $(PREFIX)/bin
+# Where to put the manual pages.
+MANDIR = $(DATAROOTDIR)/man
+
 TARGET = kabmat
 SRC_DIR = src
 BUILD_DIR = bin
-INSTALL_DIR = /usr/bin/
 DATA_DIR = ~/.local/share/kabmat
 
 CFLAGS = -std=c++17 -Wall -Wextra
@@ -32,12 +43,12 @@ clean:
 .PHONY: install
 install:
 	$(MAKE)
-	sudo cp ./$(TARGET) $(INSTALL_DIR)
-	sudo mkdir -p /usr/local/man/man1
-	sudo cp ./doc/kabmat.1 /usr/local/man/man1/
+	install -dm755 $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
+	install -Dm755 ./$(TARGET) $(DESTDIR)$(BINDIR)
+	install -Dm644 ./doc/kabmat.1 $(DESTDIR)$(MANDIR)/man1
 	rm -rf $(BUILD_DIR) $(TARGET)
 
 .PHONY: uninstall
 uninstall:
-	sudo rm -rf $(INSTALL_DIR)/$(TARGET)
-	sudo rm -rf /usr/local/man/man1/kabmat.1
+	rm $(DESTDIR)$(BINDIR)/$(TARGET)
+	rm $(DESTDIR)$(MANDIR)/man1/kabmat.1

--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ TUI program for managing kanban boards with vim-like keybindings
 
 1. get the source code from latest release or clone this repo => `git clone https://github.com/PlankCipher/kabmat.git`
 2. cd into the source code or cloned repo => `cd kabmat`
-3. run `make install`
-
-> You will be asked to enter your password for sudo to move the executables to `/usr/bin/` so that they're accessible from anywhere
+3. run `sudo make install` to build and install the program
 
 ## Usage
 


### PR DESCRIPTION
This patch modifies the Makefile to follow GNU conventions. More details about these conventions can be found [here](https://www.gnu.org/prep/standards/html_node/Makefile-Conventions.html).

The proposed changes include:

- using `install` instead of `cp` and `mkdir`
- stopping the use of `sudo` in the Makefile (if needed, run `sudo make install` instead)
- implementing `DESTDIR` for isolated environments, like package managers, and
- following the GNU-style variable names for:
  - `PREFIX`
  - `BINDIR`
  - `MANDIR` 