### PR TITLE
Makefile: fix install on non-GNU systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,11 @@ clean:
 
 .PHONY: install
 install:
-	install -dm755 $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
-	install -Dm755 ./$(TARGET) $(DESTDIR)$(BINDIR)
-	install -Dm644 ./doc/kabmat.1 $(DESTDIR)$(MANDIR)/man1
+	mkdir -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
+	cp ./$(TARGET) $(DESTDIR)$(BINDIR)
+	chmod 0755 $(DESTDIR)$(BINDIR)/$(TARGET)
+	cp ./doc/kabmat.1 $(DESTDIR)$(MANDIR)/man1
+	chmod 0644 $(DESTDIR)$(MANDIR)/man1/kabmat.1
 	$(MAKE) clean
 
 .PHONY: uninstall


### PR DESCRIPTION
The install step fails on macOS due to the missing `-D` option in `install`. This pull request fixes this issue by using `mkdir`, `cp` and `chmod` instead of `install`.

Fixes: #10 
Fixes: #14 