### PR TITLE
Esc will exit card view as well as q

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ I tried making the keybindings as intuitive and expected as possible, and for th
 
 | Key           | Function                                      |
 | ------------- | --------------------------------------------- |
-| q             | cancel and close (if in normal mode)          |
+| \<Esc\>, q    | cancel and close (if in normal mode)          |
 | \<Enter\>     | submit and close (if in normal mode)          |
 | \<Tab\>       | switch focused input (content or description) |
 | c             | open checklist items window                   |

--- a/doc/kabmat.1
+++ b/doc/kabmat.1
@@ -227,7 +227,7 @@ delete focused card
 
 .SS Card Info Window
 .TP
-.B q
+.B <Esc>, q
 cancel and close (if in normal mode)
 .TP
 .B <Enter>

--- a/src/ui/components/CardInfo/CardInfo.cpp
+++ b/src/ui/components/CardInfo/CardInfo.cpp
@@ -51,6 +51,7 @@ bool CardInfo::show(DataManager *data_manager) {
   bool canceled = false;
   while (!done && (key = wgetch(this->window))) {
     switch (key) {
+    case 27: // ESC
     case 'q': {
       // cancel and close if in normal mode
       if (this->focused_input->mode == MODE_NORMAL) {

--- a/src/ui/components/Help/Help.cpp
+++ b/src/ui/components/Help/Help.cpp
@@ -106,7 +106,7 @@ void Help::show() {
       "",
       "",
       "Card Info Window keybindings:",
-      "q         cancel and close (if in normal mode)",
+      "<Esc>, q  cancel and close (if in normal mode)",
       "<Enter>   submit and close (if in normal mode)",
       "<Tab>     switch focused input (content or description)",
       "c         open checklist items window",


### PR DESCRIPTION
When I view a card and hit esc then it will delete the content of the input field with the focus.
This PR makes Esc behave like q when viewing a card in normal mode.
